### PR TITLE
Uses Polymer 0.5.2 and vis 3.7.2

### DIFF
--- a/bower.json
+++ b/bower.json
@@ -20,7 +20,7 @@
     "tests"
   ],
   "dependencies": {
-    "polymer": "Polymer/polymer#~0.2.4",
-    "vis": "~1.0.1"
+    "vis": "^3.7.2",
+    "polymer": "^0.5.2"
   }
 }

--- a/index.html
+++ b/index.html
@@ -5,7 +5,7 @@
 	<title>&lt;a-dot&gt;</title>
 
 	<!-- Importing Web Component's Polyfill -->
-    <script src="bower_components/platform/platform.js"></script>
+    <script src="bower_components/webcomponentsjs/webcomponents.js"></script>
 
 	<!-- Importing Custom Elements -->
 	<link rel="import" href="src/a-dot.html">

--- a/src/a-dot.html
+++ b/src/a-dot.html
@@ -21,7 +21,7 @@
                 });
 			},
 			domReady: function() {
-				this._graph = new vis.Graph(this.$.container, {
+				this._graph = new vis.Network(this.$.container, {
                     dot: this.dot
                 });
 			}


### PR DESCRIPTION
Updates to Polymer 0.5.2.
vis uses `vis.Network` constructor, previously `vis.Graph`
